### PR TITLE
Skip `before_save` callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,9 @@ The configuration of the connection to the Knowledge Base is done using ENV vari
 
 The `KB::Concerns::AsKBWrapper` concern has been created in order to easily make an ActiveRecord model wrap a KB model.
 
-To use it, include it into your wrapping model, define an attribute `kb_key` on your wrapping model and call `wrap_kb` with the wrapped KB model class.
+To use it:
+- include it into your wrapping model, define an attribute `kb_key` on your wrapping model 
+- call `wrap_kb` with the wrapped KB model class (available option: `skip_callback`)
 
 You have then access to the wrapped model under `kb_model` and can delegate attributes to it, for instance:
 

--- a/lib/kb/concerns/as_kb_wrapper.rb
+++ b/lib/kb/concerns/as_kb_wrapper.rb
@@ -19,8 +19,8 @@ module KB
 
       # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/BlockLength
       class_methods do
-        def wrap_kb(model:)
-          before_save :save_underlying_kb_entity!
+        def wrap_kb(model:, skip_callback: false)
+          before_save :save_underlying_kb_entity! unless skip_callback
 
           define_method(:kb_model) do
             underlying_kb_entity = @kb_model

--- a/spec/concerns/as_kb_wrapper/save_underlying_kb_entity_spec.rb
+++ b/spec/concerns/as_kb_wrapper/save_underlying_kb_entity_spec.rb
@@ -28,6 +28,16 @@ RSpec.describe KB::Concerns::AsKBWrapper do
       expect(instance).to have_received(:save_underlying_kb_entity!).ordered
       expect(instance).to have_received(:actually_saving).ordered
     end
+
+    context 'with `skip_callback` option' do
+      let(:skip_callback) { true }
+
+      it 'calls :save_underlying_kb_entity! before actually saving the record' do # rubocop:disable RSpec/MultipleExpectations
+        instance.save
+        expect(instance).not_to have_received(:save_underlying_kb_entity!)
+        expect(instance).to have_received(:actually_saving)
+      end
+    end
   end
 end
 # rubocop:enable RSpec/SubjectStub

--- a/spec/support/shared_contexts/wrapping_active_record_class.rb
+++ b/spec/support/shared_contexts/wrapping_active_record_class.rb
@@ -1,16 +1,18 @@
-shared_context 'with a Wrapping ActiveRecord class' do
+shared_context 'with a Wrapping ActiveRecord class' do # rubocop:disable RSpec/MultipleMemoizedHelpers
   include_context 'with Mock ActiveRecord Class'
 
   let(:kb_model_class) { class_double KB::Pet, find: kb_model_instance, new: kb_model_new_instance }
   let(:kb_model_instance) { instance_double KB::Pet, save!: self, key: kb_key }
   let(:kb_model_new_instance) { instance_double KB::Pet, save!: self, key: kb_key }
   let(:kb_key) { 'Underlying KB Resource Key' }
+  let(:skip_callback) { false }
 
   let(:model_class) do
     resource_class = kb_model_class
+    wrapper_skip_callback = skip_callback
     Class.new(active_record_class) do
       include KB::Concerns::AsKBWrapper
-      wrap_kb model: resource_class
+      wrap_kb model: resource_class, skip_callback: wrapper_skip_callback
     end
   end
 end


### PR DESCRIPTION
## Why ?
We don't always want  to save  the underlying  KB entity right away. For instance the pet is created in Product before compiling all the required info on the Pet Parent.

## Changes
- Add an `skip_callback` option to the `wrap_kb` method

## Checklist
- [x] Test added
- [x] Documentation Updated 