### PR TITLE
Fix array type returning single item (return vs next)

### DIFF
--- a/lib/kb/type/array_of_conditions_type.rb
+++ b/lib/kb/type/array_of_conditions_type.rb
@@ -4,7 +4,7 @@ module Type
 
     def cast(value)
       (value || []).map do |v|
-        return v if v.is_a? KB::Condition
+        next v if v.is_a? KB::Condition
 
         KB::Condition.new v.symbolize_keys.slice(*CONDITION_KEYS)
       end

--- a/lib/kb/type/array_of_symptoms_type.rb
+++ b/lib/kb/type/array_of_symptoms_type.rb
@@ -4,7 +4,7 @@ module Type
 
     def cast(value)
       (value || []).map do |v|
-        return v if v.is_a? KB::Symptom
+        next v if v.is_a? KB::Symptom
 
         KB::Symptom.new v.symbolize_keys.slice(*SYMPTOM_KEYS)
       end


### PR DESCRIPTION
## Why?

KB::Assessment.find(_any_).symptoms / .conditions would return a single element instead of a list

## Changes

- Use `next` instead of `return` in the custom types