### PR TITLE
Throw actual errors

### DIFF
--- a/lib/kb/concerns/as_kb_wrapper.rb
+++ b/lib/kb/concerns/as_kb_wrapper.rb
@@ -28,7 +28,7 @@ module KB
             if underlying_kb_entity.blank?
               underlying_kb_entity = begin
                 model.find kb_key
-              rescue ActiveRecord::RecordNotFound
+              rescue KB::ResourceNotFound
                 model.new
               end
 

--- a/lib/kb/error.rb
+++ b/lib/kb/error.rb
@@ -1,10 +1,14 @@
 module KB
-  class Error
+  class Error < StandardError
     attr_accessor :status_code, :body
 
-    def initialize(status_code, body)
+    def initialize(status_code, body, error)
+      super(error)
       @status_code = status_code
       @body = body
+      set_backtrace error.backtrace if error
     end
   end
+
+  class ResourceNotFound < Error; end
 end

--- a/lib/kb/models/concerns/creatable.rb
+++ b/lib/kb/models/concerns/creatable.rb
@@ -10,6 +10,8 @@ module KB
       def create(attributes)
         api_response = kb_client.create(attributes)
         attributes_from_response(api_response)
+      rescue Faraday::Error => e
+        raise KB::Error.new(e.response[:status], e.response[:body], e)
       end
     end
   end

--- a/lib/kb/models/concerns/findable.rb
+++ b/lib/kb/models/concerns/findable.rb
@@ -9,8 +9,10 @@ module KB
     module ClassMethods
       def find(key, params = {})
         from_api(kb_client.find(key, params))
-      rescue Faraday::ResourceNotFound
-        raise ActiveRecord::RecordNotFound
+      rescue Faraday::ResourceNotFound => e
+        raise KB::ResourceNotFound.new(e.response[:status], e.response[:body], e)
+      rescue Faraday::Error => e
+        raise KB::Error.new(e.response[:status], e.response[:body], e)
       end
     end
   end

--- a/lib/kb/models/concerns/listable.rb
+++ b/lib/kb/models/concerns/listable.rb
@@ -14,7 +14,7 @@ module KB
       rescue Faraday::ConnectionFailed => e
         raise e
       rescue Faraday::Error => e
-        KB::Error.new(e.response[:status], e.response[:body])
+        raise KB::Error.new(e.response[:status], e.response[:body], e)
       end
     end
   end

--- a/lib/kb/models/concerns/updatable.rb
+++ b/lib/kb/models/concerns/updatable.rb
@@ -10,6 +10,8 @@ module KB
       def update(key, attributes)
         api_response = kb_client.update(key, attributes)
         attributes_from_response(api_response)
+      rescue Faraday::Error => e
+        raise KB::Error.new(e.response[:status], e.response[:body], e)
       end
     end
   end

--- a/spec/concerns/as_kb_wrapper/kb_model_spec.rb
+++ b/spec/concerns/as_kb_wrapper/kb_model_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe KB::Concerns::AsKBWrapper do
 
     context 'when the KB resource is not found' do
       before do
-        allow(kb_model_class).to receive(:find).and_raise(ActiveRecord::RecordNotFound)
+        allow(kb_model_class).to receive(:find).and_raise(KB::ResourceNotFound.new(404, 'Resource Not Found', nil))
       end
 
       it 'returns a fresh KB resource if not found' do

--- a/spec/models/concerns/findable_spec.rb
+++ b/spec/models/concerns/findable_spec.rb
@@ -44,10 +44,10 @@ RSpec.describe KB::Findable do
     end
 
     context 'when the exception is Faraday::ResourceNotFound' do
-      let(:api_exception) { Faraday::ResourceNotFound.new 'Ooops' }
+      let(:api_exception) { Faraday::ResourceNotFound.new status_code: 404, body: 'Resource Not found' }
 
-      it 'raises an ActiveRecord::RecordNotFound exception' do
-        expect { find }.to raise_exception ActiveRecord::RecordNotFound
+      it 'raises an KB::ResourceNotFound exception' do
+        expect { find }.to raise_exception KB::ResourceNotFound
       end
     end
   end


### PR DESCRIPTION
## Why?
Currently the gem returns error and the client applications (App Backend at least) is not checking the return type and process the response as if everything went fine which triggers weird errors later on like method key does not exist on object KB::Error.

## Changes

Make KB::Error extend StandardError and raise those instead of simply returning them.