### PR TITLE
Rollback the Create returning an instance as breaking `save!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-- [Breaking] `create` now returns an instance of the including class
 - Exposes `FindOrCreatable` concerns on PetParent and Pet entities
-- `create` accepts a block to initialize the entity
 
 ## [0.2.4]
 - Fix Assessment not properly localized

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ The configuration of the connection to the Knowledge Base is done using ENV vari
   - arg: `key` string
   - returns: a PetParent instance when provided an existing key or raise `ActiveRecord::RecordNotFound`
 - `create`
-  - arg: `attributes`, `&block` to initialize the entity 
-  - returns: a PetParent instance
+  - arg: `attributes` to initialize the entity 
+  - returns: the raw attributes of the created PetParent instance
   - throws an `KB::Error` exception if something went wrong
 - `find_or_create_by`
-  - arg: `attributes`, `&block` to look for or initialize the entity 
+  - arg: `attributes`, `additional_attributes` to look for or initialize the entity 
   - returns: look for a PetParent matching the passed attributes or initialize and persist one with the given attributes and launching the block provided
   - throws an `KB::Error` exception if something went wrong
 - `all`
@@ -84,11 +84,11 @@ The configuration of the connection to the Knowledge Base is done using ENV vari
   - arg: `filters` hash of filters
   - returns: an array of Pet instances matching the filters
 - `create`
-  - arg: `attributes`, `&block` to initialize the entity 
-  - returns: a Pet instance
+  - arg: `attributes` to initialize the entity 
+  - returns: the raw attributes of the Pet instance
   - throws an `KB::Error` exception if something went wrong
 - `find_or_create_by`
-  - arg: `attributes`, `&block` to look for or initialize the entity 
+  - arg: `attributes`, `additional_attributes` to look for or initialize the entity 
   - returns: look for a Pet matching the passed attributes or initialize and persist one with the given attributes and launching the block provided
   - throws an `KB::Error` exception if something went wrong
 #### Breed

--- a/lib/kb/models/concerns/creatable.rb
+++ b/lib/kb/models/concerns/creatable.rb
@@ -7,9 +7,9 @@ module KB
     end
 
     module ClassMethods
-      def create(attributes, &block)
-        kb_entity = new(attributes.stringify_keys.slice(*attribute_names), &block)
-        from_api(kb_client.create(kb_entity.attributes))
+      def create(attributes)
+        api_response = kb_client.create attributes
+        attributes_from_response(api_response)
       rescue Faraday::Error => e
         raise KB::Error.new(e.response[:status], e.response[:body], e)
       end

--- a/lib/kb/models/concerns/find_or_creatable.rb
+++ b/lib/kb/models/concerns/find_or_creatable.rb
@@ -9,8 +9,8 @@ module KB
     end
 
     module ClassMethods
-      def find_or_create_by(attributes, &block)
-        all(attributes).first || create(attributes, &block)
+      def find_or_create_by(attributes, additional_attributes)
+        all(attributes).first || new(create(additional_attributes.merge(attributes)), &:persist!)
       rescue Faraday::Error => e
         raise KB::Error.new(e.response[:status], e.response[:body], e)
       end

--- a/spec/models/concerns/creatable_spec.rb
+++ b/spec/models/concerns/creatable_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe KB::Creatable do
 
   it 'calls `create` on the configured kb_client' do
     create
-    expect(kb_client).to have_received(:create).with(attributes.with_indifferent_access)
+    expect(kb_client).to have_received(:create).with(attributes)
   end
 
   context 'when the api accepts the CREATE' do
@@ -23,8 +23,8 @@ RSpec.describe KB::Creatable do
       expect(including_class).to have_received(:attributes_from_response).with(created_entity)
     end
 
-    it 'returns an instance of the including class' do
-      expect(create).to be_a(including_class)
+    it 'returns the result of `attributes_from_response`' do
+      expect(create).to eq(including_class.attributes_from_response(created_entity))
     end
   end
 

--- a/spec/models/concerns/find_or_creatable_spec.rb
+++ b/spec/models/concerns/find_or_creatable_spec.rb
@@ -2,9 +2,7 @@ require 'spec_helper'
 
 RSpec.describe KB::FindOrCreatable do
   subject(:find_or_create_by) do
-    including_class.find_or_create_by(attributes) do |entity|
-      entity.foo = 'overriden'
-    end
+    including_class.find_or_create_by(attributes, { another_foo: 'value' })
   end
 
   include_context 'with KB Models Queryable Concerns'
@@ -26,7 +24,7 @@ RSpec.describe KB::FindOrCreatable do
   context 'when no matching entity exists' do
     it 'calls `create` on the configured kb_client' do
       find_or_create_by
-      expect(kb_client).to have_received(:create).with(attributes.merge(foo: 'overriden').stringify_keys)
+      expect(kb_client).to have_received(:create).with(attributes.merge(another_foo: 'value'))
     end
   end
 


### PR DESCRIPTION
## Why?

Making `create` return an instance broke the `save!` method of the entities...

## Changes
- Rollbacking when the method returned the raw attributes of the entity
- Simplifying the find_or_create_by to accept a hash as block is not needing on client side and would require some more complex and limiting stuff 

## Checklist
- [x] Test updated
- [x] Readme updated
- [x] ChangeLog entry updated 