### PR TITLE
Fix missing deleted_at accessors on PetParent and Pet entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.7]
+- Fix missing deleted_at accessors on PetParent and Pet entities
+
 ## [0.2.6]
 - Exposes `Destroyable` concerns on PetParent and Pet entities
 

--- a/lib/kb/models/pet.rb
+++ b/lib/kb/models/pet.rb
@@ -14,9 +14,9 @@ module KB
     private_class_method :attributes_from_response
 
     STRING_FIELDS = %i[key pet_parent_key name age_category sex breed chip species].freeze
-    DATE_FIELDS = %i[deleted_at].freeze
+    DATE_FIELDS = %i[birth_date deleted_at].freeze
     BOOLEAN_FIELDS = %i[neutered mongrel].freeze
-    FIELDS = [*STRING_FIELDS, *DATE_FIELDS, *BOOLEAN_FIELDS, :birth_date].freeze
+    FIELDS = [*STRING_FIELDS, *DATE_FIELDS, *BOOLEAN_FIELDS].freeze
 
     define_attribute_methods(*FIELDS)
 
@@ -28,7 +28,9 @@ module KB
       attribute field, :boolean
     end
 
-    attribute :birth_date, :date
+    DATE_FIELDS.each do |field|
+      attribute field, :date
+    end
 
     FIELDS.each do |field|
       define_method :"#{field}=" do |value|

--- a/lib/kb/models/pet_parent.rb
+++ b/lib/kb/models/pet_parent.rb
@@ -25,7 +25,7 @@ module KB
 
     STRING_FIELDS = %i[key partner_key first_name last_name prefix_phone_number phone_number email].freeze
     DATE_FIELDS = %i[deleted_at].freeze
-    FIELDS = [*STRING_FIELDS, *DATE_FIELDS, :birth_date].freeze
+    FIELDS = [*STRING_FIELDS, *DATE_FIELDS].freeze
 
     define_attribute_methods(*FIELDS)
 
@@ -34,6 +34,10 @@ module KB
 
     STRING_FIELDS.each do |field|
       attribute field, :string
+    end
+
+    DATE_FIELDS.each do |field|
+      attribute field, :date
     end
 
     attribute :first_name, :string, default: ''


### PR DESCRIPTION
Forgot to add them here https://github.com/barkibu/kb-ruby/pull/22