### PR TITLE
Bump version v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [0.3.2]
 - Exposes `KB::PetContract` entity
 - Add `contracts` method to `KB::Pet` and `KB::PetParent`
 
@@ -23,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.5]
 - Exposes `FindOrCreatable` concerns on PetParent and Pet entities
 
-## [0.2.4]
+## [0.2.4]
 - Fix Assessment not properly localized
 
 ## [0.2.3]
@@ -46,7 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.1] - 2020-01-12
 - Init Version: Breeds and limited PetParents/Consultations
 
-[Unreleased]: https://github.com/barkibu/kb-ruby/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/barkibu/kb-ruby/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/barkibu/kb-ruby/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/barkibu/kb-ruby/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/barkibu/kb-ruby/compare/v0.2.7...v0.3.0
 [0.2.7]: https://github.com/barkibu/kb-ruby/compare/v0.2.6...v0.2.7

--- a/lib/kb/version.rb
+++ b/lib/kb/version.rb
@@ -1,3 +1,3 @@
 module KB
-  VERSION = '0.3.1'.freeze
+  VERSION = '0.3.2'.freeze
 end


### PR DESCRIPTION
- Exposes `KB::PetContract` entity
- Add `contracts` method to `KB::Pet` and `KB::PetParent`
