### PR TITLE
Add cache to client request method :bookmark::zap:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.3.6]
+- Add cache to client request method
 
 ## [0.3.5]
 - Add Dry gem and setup config
@@ -60,7 +61,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.1] - 2020-01-12
 - Init Version: Breeds and limited PetParents/Consultations
 
-[Unreleased]: https://github.com/barkibu/kb-ruby/compare/v0.3.5...HEAD
+[Unreleased]: https://github.com/barkibu/kb-ruby/compare/v0.3.6...HEAD
+[0.3.6]: https://github.com/barkibu/kb-ruby/compare/v0.3.5...v0.3.6
 [0.3.5]: https://github.com/barkibu/kb-ruby/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/barkibu/kb-ruby/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/barkibu/kb-ruby/compare/v0.3.2...v0.3.3

--- a/lib/kb/client.rb
+++ b/lib/kb/client.rb
@@ -8,7 +8,12 @@ module KB
     end
 
     def request(sub_path, filters: {}, method: :get)
-      connection.public_send(method, sub_path, filters).body
+      return connection.public_send(method, sub_path, filters).body if method != :get
+
+      cache_key = "#{@base_url}/#{sub_path}/#{filters.sort.to_h}"
+      KB::Cache.fetch(cache_key) do
+        connection.public_send(method, sub_path, filters).body
+      end
     end
 
     def all(filters = {})

--- a/lib/kb/version.rb
+++ b/lib/kb/version.rb
@@ -1,3 +1,3 @@
 module KB
-  VERSION = '0.3.5'.freeze
+  VERSION = '0.3.6'.freeze
 end


### PR DESCRIPTION
# Add cache to client request method

## Why? 
We've added cache only to "direct" methods for entities (e.g. `PetParent.find`) but relations go through other request (e.g. PetParent.pets.all)

## Changes
Add cache to request get methods

## Known caveats:
Cache is destroyed after update/destroy for the **current** model. So, if `PetParent.pets.all` is cached and, later, a Pet is destroyed, `PetParent.pets.all` is going to return the old pet. This forces us to keep a low cache expire time. At least that's better than repeating 6 times the same query :sweat_smile: 