### PR TITLE
Add body to message in KB::Error

### DIFF
--- a/lib/kb/error.rb
+++ b/lib/kb/error.rb
@@ -8,6 +8,12 @@ module KB
       @body = body
       set_backtrace error.backtrace if error
     end
+
+    def message
+      error_msg = "Received Status: #{status_code}\n"
+      error_msg << body
+      error_msg
+    end
   end
 
   class ResourceNotFound < Error; end


### PR DESCRIPTION
## Why ?
Error Body is accessible when debugging but not on the monitoring tools (Rollbar / Sentry).

## Changes
- overwrite the message of the KB::Error

![image](https://user-images.githubusercontent.com/59359380/114153317-7de30d00-991f-11eb-83bf-e328e5268e07.png)
