### PR TITLE
Assessment - Change creation date to date time

### DIFF
--- a/lib/kb/models/assessment.rb
+++ b/lib/kb/models/assessment.rb
@@ -38,7 +38,7 @@ module KB
     attribute :conditions, :array_of_conditions
     attribute :symptoms, :array_of_symptoms
 
-    attribute :date, :date
+    attribute :date, :datetime
     attribute :finished, :boolean, default: false
 
     attribute :urgency, :string


### PR DESCRIPTION
## Why?

The time part of the date was missing on the Assessment object to sort them in order of creation.

## Changes

- Switch date to datetime

