### PR TITLE
remove warnings Dry::Configurable

### DIFF
--- a/lib/kb.rb
+++ b/lib/kb.rb
@@ -12,11 +12,11 @@ module KB
   extend Dry::Configurable
 
   setting :cache do
-    setting :instance, ActiveSupport::Cache::NullStore.new
-    setting :expires_in, 0
+    setting :instance, default: ActiveSupport::Cache::NullStore.new
+    setting :expires_in, default: 0
   end
 
-  setting :log_level, :info
+  setting :log_level, default: :info
 end
 
 require 'kb/inflections'


### PR DESCRIPTION
`Dry::Configurable` was raising warnings https://github.com/dry-rb/dry-configurable/blob/master/CHANGELOG.md#0130-2021-09-12

> /app/vendor/bundle/ruby/2.7.0/gems/dry-configurable-0.13.0/lib/dry/configurable/dsl.rb:28:in `initialize' [dry-configurable] default value as positional argument to settings is deprecated and will be removed in the next major version
> Provide a `default:` keyword argument instead
> 
> /app/vendor/bundle/ruby/2.7.0/gems/dry-configurable-0.13.0/lib/dry/configurable/dsl.rb:28:in `initialize' [dry-configurable] default value as positional argument to settings is deprecated and will be removed in the next major version
> Provide a `default:` keyword argument instead
> 
> /app/vendor/bundle/ruby/2.7.0/bundler/gems/kb-ruby-3ae8f45bd22a/lib/kb.rb:11:in `<main>' [dry-configurable] default value as positional argument to settings is deprecated and will be removed in the next major version
> Provide a `default:` keyword argument instead
>  