### PR TITLE
Add language and claimable_by to Product pulled from KB

### DIFF
--- a/lib/kb/models/product.rb
+++ b/lib/kb/models/product.rb
@@ -16,7 +16,7 @@ module KB
     private_class_method :attributes_from_response
 
     STRING_FIELDS = %i[key country name type].freeze
-    STRING_ARRAY_FIELDS = %i[exclusions inclusions features].freeze
+    STRING_ARRAY_FIELDS = %i[exclusions inclusions features claimable_by languages].freeze
     FIELDS = [*STRING_FIELDS, *STRING_ARRAY_FIELDS, :purchasable].freeze
 
     define_attribute_methods(*FIELDS)


### PR DESCRIPTION
## Why ?
The Products exposed lacked the claimable by and languages attributes

## Changes
- Parse and expose languages and claimable by attributes

## Side Note
No production app pulled the 0.10.0 version so no need to bump the version here