### PR TITLE
Expose  on PetContract entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0]
+- Expose product_key on PetContract
+
 ## [0.10.0]
 - Add KB::Product Entity
 

--- a/lib/kb/models/pet_contract.rb
+++ b/lib/kb/models/pet_contract.rb
@@ -16,7 +16,7 @@ module KB
 
     private_class_method :attributes_from_response
 
-    STRING_FIELDS = %i[key plan_key pet_key contract_number contract_document status
+    STRING_FIELDS = %i[key plan_key product_key pet_key contract_number contract_document status
                        source affiliate_online affiliate_offline
                        conversion_utm_adgroup conversion_utm_campaign
                        conversion_utm_content conversion_utm_medium
@@ -58,6 +58,10 @@ module KB
 
     def plan
       @plan ||= Plan.all.select { |plan| plan.key == plan_key }
+    end
+
+    def product
+      @product ||= Product.find product_key
     end
 
     def pet

--- a/lib/kb/version.rb
+++ b/lib/kb/version.rb
@@ -1,3 +1,3 @@
 module KB
-  VERSION = '0.10.0'.freeze
+  VERSION = '0.11.0'.freeze
 end


### PR DESCRIPTION
## Why ?

In order to switch from using plans to products in the App

## Changes
Exposes the product key on the PetContract entities