### PR TITLE
Fix key used for cache invalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.1]
+- Fix Cache invalidation deleting wrong key
+
 ## [0.15.0]
 - Add `husbpot_id` attribute on PetContract
 

--- a/lib/kb/cache.rb
+++ b/lib/kb/cache.rb
@@ -6,7 +6,7 @@ module KB
       end
 
       def fetch(key, &block)
-        instance.fetch("#{@base_url}/#{key}", expires_in: cache_expiration, &block)
+        instance.fetch(key, expires_in: cache_expiration, &block)
       end
 
       private

--- a/lib/kb/version.rb
+++ b/lib/kb/version.rb
@@ -1,3 +1,3 @@
 module KB
-  VERSION = '0.15.0'.freeze
+  VERSION = '0.15.1'.freeze
 end


### PR DESCRIPTION
## Why?

Cache invalidation on entity update is not working.

## Changes
- Fix the key used to delete the cache entry