### PR TITLE
Fix Release command missing Github identity

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
+      - name: Github whoami
+        run: |
+          git config user.name 'Barkibot'
+          git config user.email 'dev+bot@barkibu.com'
       - name: Release Gem
         uses: cadwallion/publish-rubygems-action@master
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.2]
+- Rename gems to barkibu-kb / barkibu-kb-fake
+
 ## [0.16.0]
 - Add `Hubspot` model to retrieve information from [Hubspot Relationship endpoint](https://knowledge-base-staging.herokuapp.com/swagger-ui/index.html#/Hubspot)
 - Change `husbpot_id` attribute on PetContract, now it comes from the Hubspot Relationship


### PR DESCRIPTION
## Why?
- Release failed because of missing github email identity
- Forgot to update changelog entry