### PR TITLE
Stop pushing to master on release process

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,6 @@ end
 desc 'Tags version, pushes to remote, and pushes gem'
 task release: :build do
   sh 'git', 'tag', '-m', changelog, "v#{KB::VERSION}"
-  sh 'git push origin master'
   sh "git push origin v#{KB::VERSION}"
   sh 'ls pkg/*.gem | xargs -n 1 gem push'
 end


### PR DESCRIPTION
## Why ?

I don't know why it's trying to push to master on the release task. Pushing the tag should be enough