### PR TITLE
Fix Gem Release Action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,8 @@ jobs:
         run: |
           git config user.name 'Barkibot'
           git config user.email 'dev+bot@barkibu.com'
+          git remote rename origin original
+          git remote add origin https://$GITHUB_TOKEN@github.com/${{github.repository}}
       - name: Release Gem
         uses: cadwallion/publish-rubygems-action@master
         env:


### PR DESCRIPTION
## Why?
Part of the release process is to tag the version on the repository. Unfortunately the typical git tag myTag followed by git push origin myTag is not working because the remote is an http remote without authentication...

## Changes
- Replace origin remote to inject the GITHUB_TOKEN in there
