### PR TITLE
[CI] Update checkout action in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,14 +8,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Github whoami
         run: |
           git config user.name 'Barkibot'
           git config user.email 'dev+bot@barkibu.com'
-          git remote rename origin original
-          git remote add origin https://$GITHUB_TOKEN@github.com/${{github.repository}}
       - name: Release Gem
         uses: cadwallion/publish-rubygems-action@master
         env:


### PR DESCRIPTION
Checkout action used was v1 and the authentication seemed not to be persisted for the rest of the workflow to correctly push the tag and all...

## Changes
- Update to v3 of the checkout action
- Remove the non-working remote hack 