### PR TITLE
Remove double splat non-supported by ruby 3

### DIFF
--- a/lib/kb/concerns/as_kb_wrapper.rb
+++ b/lib/kb/concerns/as_kb_wrapper.rb
@@ -44,7 +44,7 @@ module KB
           end
 
           singleton_class.instance_eval do
-            define_method(:kb_find_by) do |**attributes|
+            define_method(:kb_find_by) do |attributes|
               kb_model = model.all(attributes).first
               return nil if kb_model.nil?
 
@@ -57,7 +57,7 @@ module KB
           end
         end
 
-        def kb_find_by!(**attributes)
+        def kb_find_by!(attributes)
           kb_find_by(attributes).presence || raise(ActiveRecord::RecordNotFound)
         end
       end


### PR DESCRIPTION
Ruby 3 is less tolerant about double splat of the last argument.

We used it while it was not bringing any value and this is broken in version >= 3

Ref.: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/