### PR TITLE
Expose cache clearing method on client / model class

### DIFF
--- a/lib/kb/client.rb
+++ b/lib/kb/client.rb
@@ -37,17 +37,21 @@ module KB
     end
 
     def update(key, attributes)
-      KB::Cache.delete("#{@base_url}/#{key}")
+      clear_cache_for(key)
       connection.patch(key.to_s, attributes_to_json(attributes)).body
     end
 
     def destroy(key)
-      KB::Cache.delete("#{@base_url}/#{key}")
+      clear_cache_for(key)
       connection.delete(key.to_s).body
     end
 
     def upsert(attributes)
       connection.put('', attributes_to_json(attributes)).body
+    end
+
+    def clear_cache_for(key)
+      KB::Cache.delete("#{@base_url}/#{key}")
     end
 
     private

--- a/lib/kb/models/base_model.rb
+++ b/lib/kb/models/base_model.rb
@@ -11,6 +11,10 @@ module KB
     define_model_callbacks :save
     after_save :persist!
 
+    class << self
+      delegate :clear_cache_for, to: :kb_client
+    end
+
     def initialize(attributes = {})
       super
       @persisted = false


### PR DESCRIPTION
## Why?
As 2 apps can concurrently update the KB in some cases we want a mechanism to ensure the client can retrieve the latest updated entity.

This was already implemented but not exposed as an API of the client/model