### PR TITLE
Fix HTTP Client error parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
-- See diff: https://github.com/barkibu/kb-ruby/compare/v0.21.0...HEAD
+- See diff: https://github.com/barkibu/kb-ruby/compare/v0.22.0...HEAD
+
+# [0.22.0]
+- Fix error parsing if HTTP client returns no response
 
 ## [0.21.0]
 - Add city attribute to PetParent model

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    barkibu-kb (0.21.0)
+    barkibu-kb (0.22.0)
       activemodel (>= 4.0.2)
       activerecord
       activesupport (>= 3.0.0)
@@ -10,8 +10,8 @@ PATH
       faraday-http
       faraday_middleware
       i18n
-    barkibu-kb-fake (0.21.0)
-      barkibu-kb (= 0.21.0)
+    barkibu-kb-fake (0.22.0)
+      barkibu-kb (= 0.22.0)
       countries
       sinatra
       webmock
@@ -168,7 +168,7 @@ PLATFORMS
 DEPENDENCIES
   barkibu-kb!
   barkibu-kb-fake!
-  bundler (~> 1.17)
+  bundler (~> 2.4.12)
   byebug
   rake (>= 12.3.3)
   rspec (~> 3.0)

--- a/barkibu-kb.gemspec
+++ b/barkibu-kb.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.6'
 
   spec.add_dependency 'dry-configurable', '~> 0.9'
-  spec.add_development_dependency 'bundler', '~> 1.17'
+  spec.add_development_dependency 'bundler', '~> 2.4.12'
   spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'

--- a/lib/kb/client_resolver.rb
+++ b/lib/kb/client_resolver.rb
@@ -37,8 +37,8 @@ module KB
         call :petfamily, :hubspot
       end
 
-      def call(*args, &block)
-        new(*args, &block).call
+      def call(*args, **kwargs, &block)
+        new(*args, **kwargs, &block).call
       end
     end
 

--- a/lib/kb/errors/error.rb
+++ b/lib/kb/errors/error.rb
@@ -7,11 +7,12 @@ module KB
       @status_code = status_code
       @body = body
       @message = "Received Status: #{status_code}\n#{body}"
+      @message = error.message if error.present? && body.nil? && status_code.nil?
       set_backtrace error.backtrace if error
     end
 
     def self.from_faraday(error)
-      case error.response[:status]
+      case error.response&.[](:status)
       when 404
         ResourceNotFound
       when 409
@@ -20,7 +21,7 @@ module KB
         UnprocessableEntityError
       else
         self
-      end.new(error.response[:status], error.response[:body], error)
+      end.new(error.response&.[](:status), error.response&.[](:body), error)
     end
   end
 end

--- a/lib/kb/version.rb
+++ b/lib/kb/version.rb
@@ -1,3 +1,3 @@
 module KB
-  VERSION = '0.21.0'.freeze
+  VERSION = '0.22.0'.freeze
 end

--- a/spec/errors/error_spec.rb
+++ b/spec/errors/error_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+require 'byebug'
+RSpec.describe KB::Error do
+  describe '.from_faraday' do
+    subject(:from_faraday) { described_class.from_faraday(exception) }
+
+    let(:exception) { Faraday::Error.new('Boom', { status: status }) }
+    let(:status) { 400 }
+
+    it 'returns a KB::Error' do
+      expect(from_faraday).to be_a(described_class)
+    end
+
+    context 'with a 404' do
+      let(:status) { 404 }
+
+      it 'returns a ResourceNotFound' do
+        expect(from_faraday).to be_a(KB::ResourceNotFound)
+      end
+    end
+
+    context 'with a 409' do
+      let(:status) { 409 }
+
+      it 'returns a ConflictError' do
+        expect(from_faraday).to be_a(KB::ConflictError)
+      end
+    end
+
+    context 'with a 422' do
+      let(:status) { 422 }
+
+      it 'returns a UnprocessableEntityError' do
+        expect(from_faraday).to be_a(KB::UnprocessableEntityError)
+      end
+    end
+
+    context 'with an empty server error' do
+      let(:exception) { Faraday::TimeoutError.new }
+
+      it 'returns a KB::Error' do
+        expect(from_faraday).to be_a(described_class)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why?

When the server error raised by Faraday has a nil response, the wrapper trying to map it to a KB::Error is failing when trying to match the status code... Making us lose track of the exception

https://3.basecamp.com/3934852/buckets/27250433/chats/4857170669@6073942910


## Changes
- Fixed positional vs keyword args separation that becomes incompatible in ruby 3.0+ (https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)
- Safe access the response body and status code when mapping Faraday error into some local error
