### PR TITLE
Add referrers to `PetParent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
-- See diff: https://github.com/barkibu/kb-ruby/compare/v0.23.0...HEAD
+- See diff: https://github.com/barkibu/kb-ruby/compare/v0.24.0...HEAD
+
+# [0.24.0]
+- Add support for `.referrers` method on `PetParent`
 
 # [0.23.0]
 - Add support for `.search` method on `PetContract`

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ KB.config.log_level = :debugger # :info by default
   - returns all the KB::PetContract associated with this pet parent
 - `referrals`
   - returns all the KB::Referral associated with this pet parent
+- `referrers`
+  - returns all the KB::Referral associated with any of the pet parent's pets 
 
 #### Assessment 📄
 

--- a/lib/kb/models/pet_parent.rb
+++ b/lib/kb/models/pet_parent.rb
@@ -113,5 +113,11 @@ module KB
         Referral.from_api(referral)
       end
     end
+
+    def referrers
+      self.class.kb_client.request("#{key}/referrers").map do |referral|
+        Referral.from_api(referral)
+      end
+    end
   end
 end


### PR DESCRIPTION
## [Add ability to query referrer in kb-ruby gem](https://3.basecamp.com/3934852/buckets/27820160/todos/7130916166)

## Changes
- Add referrers method to `PetParent` to get referrals relationships.
