### PR TITLE
Remove version specifier for bundle

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,7 +168,7 @@ PLATFORMS
 DEPENDENCIES
   barkibu-kb!
   barkibu-kb-fake!
-  bundler (~> 2.4.12)
+  bundler
   byebug
   rake (>= 12.3.3)
   rspec (~> 3.0)

--- a/barkibu-kb.gemspec
+++ b/barkibu-kb.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.6'
 
   spec.add_dependency 'dry-configurable', '~> 0.9'
-  spec.add_development_dependency 'bundler', '~> 2.4.12'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
[Release task](https://github.com/barkibu/kb-ruby/actions/runs/8116361826/job/22186202800) failed because it can't find a compatible version of Bundler