### PR TITLE
Add `referrers` method to `PetParent` in fake gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
-- See diff: https://github.com/barkibu/kb-ruby/compare/v0.24.0...HEAD
+- See diff: https://github.com/barkibu/kb-ruby/compare/v0.24.1...HEAD
+
+# [0.24.1]
+- Add support for `.referrers` method on `PetParent` in fake model
 
 # [0.24.0]
 - Add support for `.referrers` method on `PetParent`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    barkibu-kb (0.23.0)
+    barkibu-kb (0.24.1)
       activemodel (>= 4.0.2)
       activerecord
       activesupport (>= 3.0.0)
@@ -10,8 +10,8 @@ PATH
       faraday-http
       faraday_middleware
       i18n
-    barkibu-kb-fake (0.23.0)
-      barkibu-kb (= 0.23.0)
+    barkibu-kb-fake (0.24.1)
+      barkibu-kb (= 0.24.1)
       countries
       sinatra
       webmock

--- a/lib/kb/fake/bounded_context/pet_family/pet_parents.rb
+++ b/lib/kb/fake/bounded_context/pet_family/pet_parents.rb
@@ -30,6 +30,10 @@ module BoundedContext
           json_response 200, referrals_by_pet_parent_key(params['key'])
         end
 
+        get '/v1/petparents/:key/referrers' do
+          json_response 200, referrers_by_pet_parent_key(params['key'])
+        end
+
         post '/v1/petparents/:key/referrals' do
           resource = JSON.parse(request.body.read)
           resource = resource.merge 'key' => SecureRandom.uuid
@@ -92,6 +96,11 @@ module BoundedContext
 
         def referrals_by_pet_parent_key(key)
           resource_state(:referrals).select { |resource| resource['referralKey'] == key }
+        end
+
+        def referrers_by_pet_parent_key(key)
+          pet_keys = resource_state(:pets).select { |pet| pet['petParentKey'] == key }.map { |pet| pet['key'] }
+          resource_state(:referrals).select { |referral| pet_keys.include? referral['referredKey'] }
         end
 
         def same_email_but_different_phone_number?(previous, new)

--- a/lib/kb/version.rb
+++ b/lib/kb/version.rb
@@ -1,3 +1,3 @@
 module KB
-  VERSION = '0.24.0'.freeze
+  VERSION = '0.24.1'.freeze
 end

--- a/spec/fake/models/pet_parent_spec.rb
+++ b/spec/fake/models/pet_parent_spec.rb
@@ -127,4 +127,45 @@ RSpec.describe KB::PetParent do
       end
     end
   end
+
+  describe '#referrers' do
+    let(:referral_pet_parent) { described_class.new described_class.create(attributes) }
+
+    let(:attributes) do
+      { phone_number: '683123123', prefix_phone_number: '+34', email: 'foo@example.com' }
+    end
+
+    before do
+      referral_pet_parent
+    end
+
+    context 'with no referrers' do
+      it 'returns an empty list' do
+        expect(referral_pet_parent.referrers).to eq([])
+      end
+    end
+
+    context 'with a referrer' do
+      let(:referrer) { described_class.create }
+      let(:pet) { KB::Pet.create(pet_parent_key: referral_pet_parent.key) }
+
+      before do
+        KB::Referral.create(referrer[:key],
+                            { type: 'pet', referred_key: pet[:key], joined_at: '2018-01-01T17:09:42.411' })
+      end
+
+      it 'returns the referrer of the pet parent' do
+        expect(referral_pet_parent.referrers.length).to eq(1)
+      end
+
+      it 'returns the referrer with all the attributes' do
+        expect(referral_pet_parent.referrers.first).to have_attributes(
+          'type' => 'pet',
+          'referral_key' => referrer[:key],
+          'referred_key' => pet[:key],
+          'joined_at' => '2018-01-01'.to_date
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
#  Add `referrers` method for `PetParent` in fake gem 

## Why?

I forgot to add the method in the fake gem.

## Changes

 Add `referrers` method for `PetParent` in fake gem 

## Checklist
- [x] Tests added/updated
- [ ] README file updated
- [x] Changelog updated
- [x] Version file `lib/kb/version.rb` updated
