### PR TITLE
Update DATE_FIELDS to include created_at in pet_parent model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
-- See diff: https://github.com/barkibu/kb-ruby/compare/v0.28...HEAD
+- See diff: https://github.com/barkibu/kb-ruby/compare/v0.29.0...HEAD
+
+## [0.29.0]
+- Add `created_at` field to PetParent DATE_FIELDS
 
 ## [0.28.0]
 - [Breaking changes] Remove Hubspot models

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    barkibu-kb (0.27.0)
+    barkibu-kb (0.28.0)
       activemodel (>= 4.0.2)
       activerecord
       activesupport (>= 3.0.0)
@@ -10,8 +10,8 @@ PATH
       faraday-http
       faraday_middleware
       i18n
-    barkibu-kb-fake (0.27.0)
-      barkibu-kb (= 0.27.0)
+    barkibu-kb-fake (0.28.0)
+      barkibu-kb (= 0.28.0)
       countries
       sinatra
       webmock

--- a/lib/kb/models/pet_parent.rb
+++ b/lib/kb/models/pet_parent.rb
@@ -43,7 +43,7 @@ module KB
 
     STRING_FIELDS = %i[key partner_name first_name last_name prefix_phone_number phone_number email country address
                        zip_code nif affiliate_code city iban_last4].freeze
-    DATE_FIELDS = %i[birth_date deleted_at].freeze
+    DATE_FIELDS = %i[birth_date deleted_at created_at].freeze
     BOOLEAN_FIELDS = %i[phone_number_verified email_verified].freeze
     FIELDS = [*STRING_FIELDS, *DATE_FIELDS, *BOOLEAN_FIELDS].freeze
 

--- a/lib/kb/version.rb
+++ b/lib/kb/version.rb
@@ -1,3 +1,3 @@
 module KB
-  VERSION = '0.28.0'.freeze
+  VERSION = '0.29.0'.freeze
 end


### PR DESCRIPTION
# Human understandable Feature/Bugfix Title

## Why?
Need to add created_at in pet_parent to be able to calculate lead teanure. https://3.basecamp.com/3934852/buckets/21281809/todos/9164392291
-- 

## Changes

Update DATE_FIELDS to include created_at in pet_parent model


 --

## Checklist
- [ ] Tests added/updated
- [ ] README file updated
- [x] Changelog updated
- [x] Version file `lib/kb/version.rb` updated
