### PR TITLE
Add .claude/worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 # intellij
 /.idea
 .env
+.claude/worktrees/


### PR DESCRIPTION
## Why?

Exclude Claude Code worktree directories from version control. These are temporary directories created during local development and should not be committed to the repository.

## Changes

- Added `.claude/worktrees/` entry to .gitignore to exclude worktree directories

## Checklist

- [x] Documentation updated
- [ ] Tests added/updated (not applicable — gitignore-only change)

## How to test

No verification needed — this is a gitignore configuration change with no functional impact. Excludes temporary local development directories from version control.