### PR TITLE
Add KB::Pet.transfer to expose the pet transfer endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
-- See diff: https://github.com/barkibu/kb-ruby/compare/v0.29.0...HEAD
+- See diff: https://github.com/barkibu/kb-ruby/compare/v0.30.0...HEAD
+
+## [0.30.0]
+- Add `KB::Pet.transfer` to call `POST /v1/pets/transfer`; add fake API route
 
 ## [0.29.0]
 - Add `created_at` field to PetParent DATE_FIELDS

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    barkibu-kb (0.28.0)
+    barkibu-kb (0.30.0)
       activemodel (>= 4.0.2)
       activerecord
       activesupport (>= 3.0.0)
@@ -10,8 +10,8 @@ PATH
       faraday-http
       faraday_middleware
       i18n
-    barkibu-kb-fake (0.28.0)
-      barkibu-kb (= 0.28.0)
+    barkibu-kb-fake (0.30.0)
+      barkibu-kb (= 0.30.0)
       countries
       sinatra
       webmock

--- a/lib/kb/fake/bounded_context/pet_family/pets.rb
+++ b/lib/kb/fake/bounded_context/pet_family/pets.rb
@@ -45,6 +45,21 @@ module BoundedContext
           json_response 200, contracts
         end
 
+        post '/v1/pets/transfer' do
+          body = JSON.parse(request.body.read)
+          pet = find_resource(:pets, body['petKey'])
+          return json_response 404, {} if pet.nil?
+
+          destination_parent = find_resource(:petparents, body['destinationPetParentKey'])
+          return json_response 422, {} if destination_parent.nil?
+
+          unless pet['petParentKey'] == body['destinationPetParentKey']
+            update_resource_state(:pets, pet.merge('petParentKey' => body['destinationPetParentKey']))
+          end
+
+          json_response 204, nil
+        end
+
         put '/v1/pets' do
           params = JSON.parse(request.body.read)
           pet_parent = find_resource(:petparents, params['petParentKey'])

--- a/lib/kb/models/pet.rb
+++ b/lib/kb/models/pet.rb
@@ -51,6 +51,14 @@ module KB
       freeze
     end
 
+    def self.transfer(pet_key:, destination_pet_parent_key:)
+      kb_client.request('transfer', filters: { pet_key: pet_key,
+                                               destination_pet_parent_key: destination_pet_parent_key },
+                                    method: :post)
+    rescue Faraday::Error => e
+      raise KB::Error.from_faraday(e)
+    end
+
     def contracts
       self.class.kb_client.request("#{key}/contracts").map do |contract|
         PetContract.from_api(contract)

--- a/lib/kb/version.rb
+++ b/lib/kb/version.rb
@@ -1,3 +1,3 @@
 module KB
-  VERSION = '0.29.0'.freeze
+  VERSION = '0.30.0'.freeze
 end

--- a/spec/fake/models/pet_spec.rb
+++ b/spec/fake/models/pet_spec.rb
@@ -62,4 +62,40 @@ RSpec.describe KB::Pet do
       end
     end
   end
+
+  describe '.transfer' do
+    let(:source_parent) { KB::PetParent.create({}) }
+    let(:destination_parent) { KB::PetParent.create({}) }
+    let(:pet) { described_class.create(name: 'Buddy', pet_parent_key: source_parent[:key]) }
+
+    context 'when the pet and destination parent exist' do
+      it 'reassigns the pet to the destination parent' do
+        described_class.transfer(pet_key: pet[:key], destination_pet_parent_key: destination_parent[:key])
+        expect(described_class.find(pet[:key]).pet_parent_key).to eq(destination_parent[:key])
+      end
+    end
+
+    context 'when the destination is the current parent (self-transfer)' do
+      it 'does not change the pet parent' do
+        described_class.transfer(pet_key: pet[:key], destination_pet_parent_key: source_parent[:key])
+        expect(described_class.find(pet[:key]).pet_parent_key).to eq(source_parent[:key])
+      end
+    end
+
+    context 'when the pet does not exist' do
+      it 'raises KB::ResourceNotFound' do
+        expect do
+          described_class.transfer(pet_key: 'missing-key', destination_pet_parent_key: destination_parent[:key])
+        end.to raise_error(KB::ResourceNotFound)
+      end
+    end
+
+    context 'when the destination parent does not exist' do
+      it 'raises KB::UnprocessableEntityError' do
+        expect do
+          described_class.transfer(pet_key: pet[:key], destination_pet_parent_key: 'missing-parent-key')
+        end.to raise_error(KB::UnprocessableEntityError)
+      end
+    end
+  end
 end

--- a/spec/models/pet_spec.rb
+++ b/spec/models/pet_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+RSpec.describe KB::Pet do
+  let(:base_url) { 'https://test_api_barkkb.com/v1/pets' }
+  let(:pet_key) { 'pet-uuid-123' }
+  let(:destination_pet_parent_key) { 'parent-uuid-456' }
+
+  describe '.transfer' do
+    subject(:transfer) do
+      described_class.transfer(pet_key: pet_key, destination_pet_parent_key: destination_pet_parent_key)
+    end
+
+    context 'when the transfer succeeds' do
+      before do
+        stub_request(:post, "#{base_url}/transfer")
+          .to_return(status: 204, body: '')
+      end
+
+      it 'POSTs to the transfer endpoint with camelCase keys' do
+        transfer
+        expect(
+          a_request(:post, "#{base_url}/transfer")
+            .with(body: { petKey: pet_key, destinationPetParentKey: destination_pet_parent_key }.to_json)
+        ).to have_been_made
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when the pet is not found' do
+      before do
+        stub_request(:post, "#{base_url}/transfer")
+          .to_return(status: 404, body: '{}')
+      end
+
+      it { expect { transfer }.to raise_error(KB::ResourceNotFound) }
+    end
+
+    context 'when the destination parent is invalid' do
+      before do
+        stub_request(:post, "#{base_url}/transfer")
+          .to_return(status: 422, body: '{}')
+      end
+
+      it { expect { transfer }.to raise_error(KB::UnprocessableEntityError) }
+    end
+  end
+end


### PR DESCRIPTION
## Why?

Global Admin reassigns pets by writing directly to KB's Postgres — the only remaining direct write from Global Admin to KB. Without an API call, KB's domain events don't fire, Segment never removes the pet from the source parent's list, and the KB connection can't be made read-only. This PR exposes barkkb-services-kotlin's new `POST /v1/pets/transfer` endpoint so Global Admin can call it instead of touching the DB directly.

- Basecamp: https://app.basecamp.com/3934852/buckets/27820160/todos/9980020666

## Changes

- `KB::Pet.transfer(pet_key:, destination_pet_parent_key:)` — POSTs to `/v1/pets/transfer`; wraps `Faraday::Error` into `KB::Error` like every other concern.
- Fake API: `POST /v1/pets/transfer` route that validates the pet and destination parent exist, no-ops on self-transfer (matching the real API's early return), and updates in-memory pet state.
- Version bump to 0.30.0.

## Checklist
- [x] Tests added/updated
- [ ] Documentation updated

## How to test

Tested manually against staging KB (barkkb-services-kotlin with PR #472):

```bash
env $(cat .env.staging | grep -v '^#' | xargs) bundle exec irb -r ./lib/barkibu-kb
```

```ruby
irb> KB::Pet.transfer(pet_key: 'ed80df34-7e81-4f83-85d5-54c09188e0c3', destination_pet_parent_key: '2fcacc4a-3a32-4d6c-9d29-d2f4d5996355')
=> nil
```

Segment updated correctly for both parents — CustomerIO profiles reflect the transfer:
- Source parent: https://fly.customer.io/workspaces/101774/journeys/people/8e9b0600e3d101e4d101
- Destination parent: https://fly.customer.io/workspaces/101774/journeys/people/8e9b0600c2d101c3d101

Automated specs also cover the HTTP contract and the fake route:

```bash
bundle exec rspec spec/models/pet_spec.rb spec/fake/models/pet_spec.rb
```