### PR TITLE
Add KB::Pet#pet_parent to call PetParent.find

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
-- See diff: https://github.com/barkibu/kb-ruby/compare/v0.30.0...HEAD
+- See diff: https://github.com/barkibu/kb-ruby/compare/v0.31.0...HEAD
+
+## [0.31.0]
+- Add `KB::Pet#pet_parent`, a memoized lookup via `PetParent.find`
 
 ## [0.30.0]
 - Add `KB::Pet.transfer` to call `POST /v1/pets/transfer`; add fake API route

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    barkibu-kb (0.30.0)
+    barkibu-kb (0.31.0)
       activemodel (>= 4.0.2)
       activerecord
       activesupport (>= 3.0.0)
@@ -10,8 +10,8 @@ PATH
       faraday-http
       faraday_middleware
       i18n
-    barkibu-kb-fake (0.30.0)
-      barkibu-kb (= 0.30.0)
+    barkibu-kb-fake (0.31.0)
+      barkibu-kb (= 0.31.0)
       countries
       sinatra
       webmock

--- a/lib/kb/models/pet.rb
+++ b/lib/kb/models/pet.rb
@@ -64,5 +64,9 @@ module KB
         PetContract.from_api(contract)
       end
     end
+
+    def pet_parent
+      @pet_parent ||= PetParent.find(pet_parent_key)
+    end
   end
 end

--- a/lib/kb/version.rb
+++ b/lib/kb/version.rb
@@ -1,3 +1,3 @@
 module KB
-  VERSION = '0.30.0'.freeze
+  VERSION = '0.31.0'.freeze
 end

--- a/spec/fake/models/pet_spec.rb
+++ b/spec/fake/models/pet_spec.rb
@@ -98,4 +98,15 @@ RSpec.describe KB::Pet do
       end
     end
   end
+
+  describe '#pet_parent' do
+    subject(:pet_parent) { described_class.find(pet[:key]).pet_parent }
+
+    let(:existing_pet_parent) { KB::PetParent.create({}) }
+    let(:pet) { described_class.create(name: 'Buddy', pet_parent_key: existing_pet_parent[:key]) }
+
+    it 'returns the pet parent the pet belongs to' do
+      expect(pet_parent.key).to eq(existing_pet_parent[:key])
+    end
+  end
 end

--- a/spec/models/pet_spec.rb
+++ b/spec/models/pet_spec.rb
@@ -45,4 +45,25 @@ RSpec.describe KB::Pet do
       it { expect { transfer }.to raise_error(KB::UnprocessableEntityError) }
     end
   end
+
+  describe '#pet_parent' do
+    subject(:pet) { described_class.new(key: pet_key, pet_parent_key: pet_parent_key) }
+
+    let(:pet_parent_key) { 'parent-uuid-456' }
+    let(:pet_parent_url) { "https://test_api_barkkb.com/v1/petparents/#{pet_parent_key}" }
+
+    before do
+      stub_request(:get, pet_parent_url)
+        .to_return(status: 200, body: { key: pet_parent_key }.to_json)
+    end
+
+    it 'returns the pet parent' do
+      expect(pet.pet_parent).to have_attributes(key: pet_parent_key)
+    end
+
+    it 'memoizes the lookup' do
+      2.times { pet.pet_parent }
+      expect(a_request(:get, pet_parent_url)).to have_been_made.once
+    end
+  end
 end


### PR DESCRIPTION
## Why?
`KB::Pet` has no `pet_parent` instance method, so Global Admin has been carrying a monkey-patch for it in `config/initializers/barkibu_kb_monkey_patch.rb`. This gem is the right place for it — Global Admin shouldn't need to patch a core model just to look up a pet's owner.

- Basecamp: https://3.basecamp.com/3934852/buckets/27820160/todos/10070209628

Once this ships, a follow-up PR in `global_admin` bumps `barkibu-kb` and deletes the monkey-patch file.

## Changes
- `KB::Pet#pet_parent`: memoized lookup via `PetParent.find(pet_parent_key)`, same pattern as the monkey-patch it replaces.
- **Known tradeoff, intentional:** `KB::Pet.transfer` can move a pet to a different parent. Because the lookup is memoized per instance, an already-loaded `Pet` object keeps returning the parent it had at load time even after a transfer — callers need `#reload` (or to re-fetch the pet) to see the new parent. We're matching the existing monkey-patch's behavior rather than introducing a new caching semantic; this was discussed and is a deliberate choice, not an oversight.
- Bumped to `0.31.0` and updated `CHANGELOG.md`/`Gemfile.lock` to match, following the same two-commit shape as the `.transfer` release (#98).

## Checklist
- [x] Tests added/updated
- [ ] Documentation updated

## How to test
Automated tests cover it:
- `spec/models/pet_spec.rb` — `#pet_parent`, stubs `GET /v1/petparents/:key`, asserts the result, and asserts the memoization (a second call doesn't re-hit the network).
- `spec/fake/models/pet_spec.rb` — `#pet_parent`, exercises the same method against the fake backend.

Run with: `docker compose run --rm kb bundle exec rspec spec/models/pet_spec.rb spec/fake/models/pet_spec.rb`

## Upgrade Deployment Instructions
Publishing this gem version to RubyGems is a separate, manual step (`workflow_dispatch` → "Publish Gem") — not run as part of this PR. Global Admin's `bundle update barkibu-kb` and monkey-patch removal wait on that release.