### PR TITLE
Fix the release workflow: bump publish-rubygems-action to v3

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
           git config user.name 'Barkibot'
           git config user.email 'dev+bot@barkibu.com'
       - name: Release Gem
-        uses: discourse/publish-rubygems-action@v2
+        uses: discourse/publish-rubygems-action@v3
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           RUBYGEMS_API_KEY: ${{secrets.RUBYGEMS_API_KEY}}


### PR DESCRIPTION
## Why?

Today's release run for 0.32.0 failed (https://github.com/barkibu/kb-ruby/actions/runs/29078151973). Root cause: the **v2 action image ships Ruby 2.7.8** — it can't install modern bundler and fails to `bundle install` a lockfile containing gems that require Ruby >= 3.2 (`connection_pool` 3.0.2, pulled in by #100), so the run dies before reaching the actual release step.

The actual release logic lives in **this repo's own Rakefile**, whose custom `rake release` already builds, tags and pushes **both** gemspecs — nothing there needs changing.

## Changes

One line: `discourse/publish-rubygems-action@v2` → `@v3` (runs on `ruby:3`).

Known cosmetic quirk: the action's own version-detection line logs a non-fatal `nil.version` error on multi-gemspec repos; nothing downstream depends on it here (the Rakefile reads `KB::VERSION` itself).

## How to test

One-time prep for this release: delete the existing `v0.32.0` tag first (`git push origin :refs/tags/v0.32.0`) — it was created manually today and `rake release` wants to create it itself (same commit, so consumers pinning the tag are unaffected). Then merge and dispatch the workflow: it should publish `barkibu-kb 0.32.0` + `barkibu-kb-fake 0.32.0` and recreate the tag. Verify with `gem search -e -r barkibu-kb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dppT6P16FuhSY8W32EgYu