### PR TITLE
Instrument silent KB::ResourceNotFound rescue in AsKBWrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
-- See diff: https://github.com/barkibu/kb-ruby/compare/v0.32.0...HEAD
+- See diff: https://github.com/barkibu/kb-ruby/compare/v0.33.0...HEAD
+
+## [0.33.0]
+- Instrument the silent `KB::ResourceNotFound` rescue in `AsKBWrapper#kb_model`: emits an `ActiveSupport::Notifications` event `kb.resource_not_found` with `wrapper_class`, `kb_model`, `kb_key` and the original `error` before returning the empty fallback object. Consumers (e.g. connectedhealth-backend) can subscribe to log/alert on this event to observe stale `kb_key`s instead of silently serving nil-filled records. No behavior change — the rescue still returns a fresh, empty model instance.
 
 ## [0.32.0]
 - Allow Ruby 3.3/3.4: raise `required_ruby_version` ceiling to `< 3.6` (floor stays `>= 2.6`)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    barkibu-kb (0.32.0)
+    barkibu-kb (0.33.0)
       activemodel (>= 4.0.2)
       activerecord
       activesupport (>= 3.0.0)
@@ -10,8 +10,8 @@ PATH
       faraday-http
       faraday_middleware
       i18n
-    barkibu-kb-fake (0.32.0)
-      barkibu-kb (= 0.32.0)
+    barkibu-kb-fake (0.33.0)
+      barkibu-kb (= 0.33.0)
       countries
       sinatra
       webmock

--- a/lib/kb/concerns/as_kb_wrapper.rb
+++ b/lib/kb/concerns/as_kb_wrapper.rb
@@ -33,7 +33,14 @@ module KB
             if underlying_kb_entity.blank?
               underlying_kb_entity = begin
                 model.find kb_key
-              rescue KB::ResourceNotFound
+              rescue KB::ResourceNotFound => e
+                ActiveSupport::Notifications.instrument(
+                  'kb.resource_not_found',
+                  wrapper_class: self.class.name,
+                  kb_model: model.name,
+                  kb_key: kb_key,
+                  error: e
+                )
                 model.new
               end
 

--- a/lib/kb/version.rb
+++ b/lib/kb/version.rb
@@ -1,3 +1,3 @@
 module KB
-  VERSION = '0.32.0'.freeze
+  VERSION = '0.33.0'.freeze
 end

--- a/spec/concerns/as_kb_wrapper/kb_model_spec.rb
+++ b/spec/concerns/as_kb_wrapper/kb_model_spec.rb
@@ -34,6 +34,27 @@ RSpec.describe KB::Concerns::AsKBWrapper do
       it 'returns a fresh KB resource if not found' do
         expect(instance.kb_model).to be kb_model_new_instance
       end
+
+      it 'instruments a kb.resource_not_found event with wrapper class, kb model and kb_key' do # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
+        payload = nil
+        subscription = ActiveSupport::Notifications.subscribe('kb.resource_not_found') do |*args|
+          event = ActiveSupport::Notifications::Event.new(*args)
+          payload = event.payload
+        end
+
+        begin
+          instance.kb_model
+        ensure
+          ActiveSupport::Notifications.unsubscribe(subscription)
+        end
+
+        expect(payload).to include(
+          wrapper_class: model_class.name,
+          kb_model: kb_model_class.name,
+          kb_key: kb_key
+        )
+        expect(payload[:error]).to be_a(KB::ResourceNotFound)
+      end
     end
   end
 end


### PR DESCRIPTION
## Problem

`AsKBWrapper#kb_model` rescues `KB::ResourceNotFound` and silently returns an empty model instance:

```ruby
model.find kb_key
rescue KB::ResourceNotFound
  model.new
```

No logging, no error tracking. Every delegated attribute (`first_name`, `last_name`, `phone_number`, `email`...) then resolves to nil, indistinguishable from a legitimately empty record. This made a production incident (connectedhealth-backend, Basecamp #10153106859 — 28 user accounts returning nil-filled profiles despite complete data in KB, crashing barkibu-app on an unguarded cast) impossible to root-cause after the fact: no trace of which `kb_key` failed to resolve, or when.

## Fix

Emit an `ActiveSupport::Notifications` event `kb.resource_not_found` right before falling back to the empty instance, carrying `wrapper_class`, `kb_model`, `kb_key` and the original error. Chosen over a hardcoded Sentry/Datadog call to keep the gem observability-agnostic — consumers subscribe and route to whatever they use.

No behavior change for existing consumers: the rescue still returns the same empty model instance. Version bumped to 0.33.0.

## Suggested consumer wiring (connectedhealth-backend)

```ruby
ActiveSupport::Notifications.subscribe('kb.resource_not_found') do |*args|
  event = ActiveSupport::Notifications::Event.new(*args)
  Logs.log_warn(message: 'kb_resource_not_found', **event.payload.except(:error))
  Sentry.capture_exception(event.payload[:error], extra: event.payload.except(:error))
end
```

## Testing

- New spec covers the event payload (`spec/concerns/as_kb_wrapper/kb_model_spec.rb`).
- Full suite: 158 examples, 0 failures.
- Rubocop clean.

## Context

Root-cause investigation: KB circuit breaker only covers transport failures (confirmed via `client_resilience.rb` + its spec) and returns an explicit 503, never a nil payload. `KB::Cache` doesn't cache the empty fallback either (rescue lives outside the cache wrapper). The `ResourceNotFound` rescue in `as_kb_wrapper.rb` is the only place a stale/unresolvable `kb_key` degrades silently into nil-filled data — this PR closes that observability gap. It doesn't fix the trigger (still unconfirmed: network blip vs Global Admin merge vs other), but makes future occurrences traceable.